### PR TITLE
Added WAF SQLi rule to API Gateway WebACL

### DIFF
--- a/cdk/lib/api-gateway-stack.ts
+++ b/cdk/lib/api-gateway-stack.ts
@@ -1665,6 +1665,22 @@ export class ApiGatewayStack extends cdk.Stack {
             metricName: "LimitRequests1000",
           },
         },
+        {
+          name: "AWS-AWSManagedRulesSQLiRuleSet",
+          priority: 3,
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: "AWS",
+              name: "AWSManagedRulesSQLiRuleSet",
+            },
+          },
+          overrideAction: { none: {} },
+          visibilityConfig: {
+            sampledRequestsEnabled: true,
+            cloudWatchMetricsEnabled: true,
+            metricName: "AWS-AWSManagedRulesSQLiRuleSet",
+          },
+        }
       ],
     });
     const wafAssociation = new wafv2.CfnWebACLAssociation(


### PR DESCRIPTION
Change made:
- Added `AWSManagedRulesSQLiRuleSet` to the existing WebACL in `api-gateway-stack.ts`.
- This rule helps prevent SQL injection attacks.
- Deployed the update using CDK to verify the rule is applied correctly.